### PR TITLE
Optimize getAddress queries

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 16.13.0
+mongodb 4.4.10

--- a/config/default.js
+++ b/config/default.js
@@ -19,7 +19,6 @@ module.exports = {
       useNewUrlParser: true,
       useUnifiedTopology: true,
       keepAlive: true,
-      socketTimeoutMS: 0,
       useFindAndModify: false,
       autoIndex: false,
     },

--- a/config/default.js
+++ b/config/default.js
@@ -21,6 +21,7 @@ module.exports = {
       keepAlive: true,
       socketTimeoutMS: 0,
       useFindAndModify: false,
+      autoIndex: false,
     },
   },
   taraxa: {

--- a/config/production.js
+++ b/config/production.js
@@ -1,0 +1,7 @@
+module.exports = {
+  mongo: {
+    options: {
+      poolSize: 20,
+    },
+  },
+};

--- a/lib/address.js
+++ b/lib/address.js
@@ -8,54 +8,30 @@ export async function getAddress(query) {
     const activity = await Promise.all([
       Tx.aggregate([
         { $match: { to: id, status: true } },
-        { $group: { _id: id, value: { $sum: '$value' } } },
-      ]),
+        { $group: { _id: '$to', value: { $sum: '$value' } } },
+      ]).hint({ to: 1, status: 1, value: 1 }),
       Tx.aggregate([
         { $match: { from: id, status: true } },
-        {
-          $group: {
-            _id: id,
-            value: {
-              $sum: '$value',
-            },
-          },
-        },
-      ]),
+        { $group: { _id: '$from', value: { $sum: '$value' } } },
+      ]).hint({ from: 1, status: 1, value: 1 }),
       Tx.aggregate([
         { $match: { from: id } },
-        {
-          $group: {
-            _id: id,
-            gas: {
-              $sum: {
-                $multiply: ['$gasUsed', '$gasPrice'],
-              },
-            },
-          },
-        },
-      ]),
+        { $group: { _id: '$from', gas: { $sum: { $multiply: ['$gasUsed', '$gasPrice'] } } } },
+      ]).hint({ from: 1, gasUsed: 1, gasPrice: 1 }),
       Block.aggregate([
         { $match: { author: id } },
         { $group: { _id: '$author', count: { $sum: 1 } } },
       ]),
-      Block.find({
-        author: id,
-      })
-        .sort({ timestamp: -1 })
-        .limit(1),
+      Block.find({ author: id }).sort({ timestamp: -1 }).limit(1),
       Block.aggregate([
         { $match: { author: id } },
-        { $group: { _id: id, value: { $sum: '$gasUsed' } } },
-      ]),
-      Tx.find({
-        $or: [{ from: id }, { to: id }],
-      })
+        { $group: { _id: '$author', value: { $sum: '$gasUsed' } } },
+      ]).hint({ author: 1, gasUsed: 1 }),
+      Tx.find({ $or: [{ from: id }, { to: id }] })
         .sort({ timestamp: sortOrder })
         .skip(skip)
         .limit(limit),
-      Tx.countDocuments({
-        $or: [{ from: id }, { to: id }],
-      }),
+      Tx.countDocuments({ $or: [{ from: id }, { to: id }] }),
     ]);
 
     const received = activity[0];

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const mongoose = require('mongoose');
 const config = require('config');
 const models = require('../models');
@@ -11,7 +12,7 @@ const readyStates = {
 
 let pendingPromise = null;
 
-async function useDb(cb = null) {
+async function useDb(overrideOptions = {}, cb = null) {
   const { readyState } = mongoose.connection;
 
   // TODO: May need to handle concurrent requests
@@ -29,17 +30,17 @@ async function useDb(cb = null) {
     }
     return models;
   }
-
+  const options = Object.assign({}, config.mongo.options, overrideOptions);
   if (process.env.NODE_ENV === 'development') {
     // In development mode, use a global variable so that the value
     // is preserved across module reloads caused by HMR (hot module replacement).
     if (!global._mongoClientPromise) {
-      global._mongoClientPromise = mongoose.connect(config.mongo.uri, config.mongo.options);
+      global._mongoClientPromise = mongoose.connect(config.mongo.uri, options);
     }
     pendingPromise = global._mongoClientPromise;
   } else {
     // In production mode, it's best to not use a global variable.
-    pendingPromise = mongoose.connect(config.mongo.uri, config.mongo.options);
+    pendingPromise = mongoose.connect(config.mongo.uri, options);
   }
 
   try {
@@ -54,14 +55,14 @@ async function useDb(cb = null) {
   return models;
 }
 
-function withDb(handler) {
+function withDb(handler, overrideOptions = {}) {
   return async (req, res) => {
     const next = () => {
       req.models = models;
       return handler(req, res);
     };
 
-    return useDb(next);
+    return useDb(overrideOptions, next);
   };
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,4 +1,3 @@
-require('dotenv').config();
 const mongoose = require('mongoose');
 const config = require('config');
 const models = require('../models');

--- a/migrations/202111231702_address_indexes.js
+++ b/migrations/202111231702_address_indexes.js
@@ -1,0 +1,36 @@
+const { createIndexes } = require('./migration');
+
+(async () => {
+  await createIndexes([
+    [
+      'Tx',
+      [
+        { to: 1, status: 1, value: 1 },
+        { background: true, sparse: true },
+      ],
+    ],
+    [
+      'Tx',
+      [
+        { from: 1, status: 1, value: 1 },
+        { background: true, sparse: true },
+      ],
+    ],
+    [
+      'Tx',
+      [
+        { from: 1, gasUsed: 1, gasPrice: 1 },
+        { background: true, sparse: true },
+      ],
+    ],
+    ['Tx', [{ timestamp: -1 }, { background: true }]],
+    ['Block', [{ timestamp: -1 }, { background: true }]],
+    [
+      'Block',
+      [
+        { author: 1, gasUsed: 1 },
+        { background: true, sparse: true },
+      ],
+    ],
+  ]);
+})();

--- a/migrations/202111231702_address_indexes.js
+++ b/migrations/202111231702_address_indexes.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const { createIndexes } = require('./migration');
 
 (async () => {

--- a/migrations/migration.js
+++ b/migrations/migration.js
@@ -1,0 +1,40 @@
+require('dotenv').config();
+const { useDb } = require('../lib/db');
+
+// 30m should be enough to create indices
+const socketTimeoutMS = 60000 * 30;
+
+async function createIndexes(specs) {
+  try {
+    const start = new Date();
+    console.log('Creating indexes...');
+    const models = await useDb({ socketTimeoutMS });
+
+    let indexNumber = 0;
+    for (const [model, args] of specs) {
+      indexNumber++;
+      console.log(`Creating index ${indexNumber}`);
+
+      if (undefined === models[model]) {
+        throw new Error(`Couldn't find model "${model}" for index ${indexNumber}`);
+      }
+
+      const indexName = await models[model].collection.createIndex(...args);
+
+      console.log(`Created index ${indexNumber} for model ${model} with name "${indexName}"`);
+    }
+
+    const finish = new Date();
+    const durationSeconds = (finish - start) / 1000;
+
+    console.log(`Finished creating indexes in ${durationSeconds}s`);
+
+    process.exit(0);
+  } catch (e) {
+    console.error('An error ocurred while creating the index');
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+module.exports = { createIndexes };

--- a/migrations/migration.js
+++ b/migrations/migration.js
@@ -5,12 +5,20 @@ const { useDb } = require('../lib/db');
 const socketTimeoutMS = 60000 * 30;
 const serverSelectionTimeoutMS = 60000 * 30;
 const connectTimeoutMS = 60000 * 30;
+const keepAliveInitialDelay = 5000;
+const heartbeatFrequencyMS = 1000;
 
 async function createIndexes(specs) {
   try {
     const start = new Date();
     console.log('Creating indexes...');
-    const models = await useDb({ socketTimeoutMS, serverSelectionTimeoutMS, connectTimeoutMS });
+    const models = await useDb({
+      keepAliveInitialDelay,
+      socketTimeoutMS,
+      serverSelectionTimeoutMS,
+      connectTimeoutMS,
+      heartbeatFrequencyMS,
+    });
 
     let indexNumber = 0;
     for (const [model, args] of specs) {

--- a/migrations/migration.js
+++ b/migrations/migration.js
@@ -3,12 +3,14 @@ const { useDb } = require('../lib/db');
 
 // 30m should be enough to create indices
 const socketTimeoutMS = 60000 * 30;
+const serverSelectionTimeoutMS = 60000 * 30;
+const connectTimeoutMS = 60000 * 30;
 
 async function createIndexes(specs) {
   try {
     const start = new Date();
     console.log('Creating indexes...');
-    const models = await useDb({ socketTimeoutMS });
+    const models = await useDb({ socketTimeoutMS, serverSelectionTimeoutMS, connectTimeoutMS });
 
     let indexNumber = 0;
     for (const [model, args] of specs) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cors": "^2.8.5",
         "cytoscape": "^3.17.0",
         "cytoscape-canvas": "^3.0.1",
+        "dotenv": "^10.0.0",
         "eslint-plugin-react": "^7.27.1",
         "ethereumjs-util": "^6.2.1",
         "lint-staged": "^12.0.3",
@@ -3607,6 +3608,14 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/duplexer3": {
@@ -13268,6 +13277,11 @@
       "version": "4.19.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-4.19.0.tgz",
       "integrity": "sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ=="
+    },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "duplexer3": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cors": "^2.8.5",
     "cytoscape": "^3.17.0",
     "cytoscape-canvas": "^3.0.1",
+    "dotenv": "^10.0.0",
     "eslint-plugin-react": "^7.27.1",
     "ethereumjs-util": "^6.2.1",
     "lint-staged": "^12.0.3",


### PR DESCRIPTION
This adds indexes needed top optimize the queries inside `getAddress` and changes the queries to use them. Also added `dotenv` to allow the migration script to read `.env`. On a side note, I fixed the delegation worker to re-use connections (had missed it in prior pr).