### PR TITLE
Add indexes to optimize find Tx query

### DIFF
--- a/migrations/202111241251_tx_find_indexes.js
+++ b/migrations/202111241251_tx_find_indexes.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+const { createIndexes } = require('./migration');
+
+(async () => {
+  await createIndexes([
+    ['Tx', [{ from: 1, timestamp: -1 }, { background: true }]],
+    ['Tx', [{ to: 1, timestamp: -1 }, { background: true }]],
+    ['Tx', [{ from: 1, timestamp: 1 }, { background: true }]],
+    ['Tx', [{ to: 1, timestamp: 1 }, { background: true }]],
+  ]);
+})();


### PR DESCRIPTION
These indexes improve the performance to fetch the Tx for the getAddress call.