### PR TITLE
Specify AppSignal workdir outside /tmp to avoid agent crashing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY package* ./
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 
+RUN mkdir /appsignal
+ENV APPSIGNAL_WORKING_DIRECTORY_PATH /appsignal
+
 # skip trying to install husky hooks
 RUN npm set-script postinstall ""
 RUN npm ci


### PR DESCRIPTION
After doing some debugging with AppSignal support, it seems like the appsignal linux agent is crashing due to some permissions agent involving `/tmp` - and only a part of the metrics is being correctly sent. This should fix the issue and get us full metrics. 